### PR TITLE
Some dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM sonarqube:5.1
-COPY sonar-perf-plugin.jar /opt/sonarqube/extensions/plugins/sonar-perf-plugin.jar
+COPY target/*.jar /opt/sonarqube/extensions/plugins/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TAG=sonar-stool
-ID=`docker ps | grep $(TAG) | cut -f1 -d' '`
 SHELLINIT=boot2docker shellinit 1>tmp; . ./tmp; rm ./tmp
+ID=`$(SHELLINIT) && docker ps | grep $(TAG) | cut -f1 -d' '`
 
 help:
 	@echo "build 	- build the docker container"
@@ -11,6 +11,7 @@ help:
 	@echo "open  	- open sonar in your browser"
 
 build:
+	mvn package
 	@$(SHELLINIT) && docker build -t $(TAG) .
 
 start:


### PR DESCRIPTION
- `make build` now compiles a jar that gets copied into the container
- Make sure we shell init before setting the container id
